### PR TITLE
MAE-652: Add linter and readme file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical._
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+### Core overrides
+_If the PR overrides/patches a core file, then please explain here, for each file:_
+
+1. _Which file it is_
+2. _The reason why it was overridden/patched_
+3. _What the override/patch consists of_
+
+## Comments
+_Anything else you would like the reviewer to note_

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,23 @@
+name: Linters
+
+on: pull_request
+
+env:
+  GITHUB_BASE_REF: ${{ github.base_ref }}
+
+jobs:
+  run-linters:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install phpcs
+        run: cd bin && ./install-php-linter
+
+      - name: Fetch target branch
+        run: git fetch -n origin ${GITHUB_BASE_REF}
+
+      - name: Run phpcs linter
+        run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' '*.module' '*.inc' '*.install' '*.theme' ':!*.features.*' ':!vendor' | xargs -r ./bin/drupal/coder/vendor/bin/phpcs --standard=drupal.phpcs.xml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Gift-Aid Webform Integration
+Integration of [Webform](https://www.drupal.org/project/webform) with [CiviCRM Gift Aid Extension](https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid).

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Clone Drupal Coder repo
+if [ ! -d drupal/coder ]; then
+  git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder
+  cd drupal/coder
+  composer install
+fi

--- a/drupal.phpcs.xml
+++ b/drupal.phpcs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="PHPCS Drupal Ruleset">
+  <description>PHP CodeSniffer configuration for Drupal development.</description>
+
+  <arg name="extensions" value="php,module,inc,install,theme"/>
+
+  <config name="drupal_core_version" value="7"/>
+
+  <!-- Drupal sniffs -->
+  <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
+    <exclude name="Drupal.Files.TxtFileLineLength.TooLong"/>
+  </rule>
+</ruleset>

--- a/giftaid_webform_integration.info
+++ b/giftaid_webform_integration.info
@@ -1,5 +1,6 @@
 name = Gift-Aid Webform Integration
 description = Integration of webform with CiviCRM Gift Aid Extension
 core = 7.x
+version = 7.x-1.0
 package = CiviCRM
 dependencies[] = webform_civicrm

--- a/giftaid_webform_integration.module
+++ b/giftaid_webform_integration.module
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * giftaid_webform_integration.module
+ */
+
+/**
  * Implements hook_init().
  */
 function giftaid_webform_integration_init() {
@@ -42,34 +47,30 @@ function giftaid_webform_integration_form_alter(&$form, &$form_state, $form_id) 
 }
 
 /**
- * This function contains the logic to make giftaid declaration from webform. 
- * This is called inside giftaid_webform_integration_webform_submission_insert().
- * 
- * @param Object $node
- * @param Object $submission
+ * This function contains the logic to make giftaid declaration from webform.
  */
 function giftaid_wf_submission($node, $submission) {
   $webformNid = $submission->nid;
   $submittedValues = $submission->data;
   $webformFields = array();
   $webformFields = $node->webform['components'];
-  foreach($node->webform['components'] as $component) {
+  foreach ($node->webform['components'] as $component) {
     $webformFields[$component['form_key']] = $component['cid'];
   }
 
   $contactId = $submittedValues[$webformFields['civicrm_1_contact_1_contact_existing']][0];
 
-  // get field key for eligibility.
+  // Get field key for eligibility.
   $eligibleForGiftAidField = get_eligibility_form_key_name();
   $eligibilityFieldId = $webformFields[$eligibleForGiftAidField];
 
-  // get address.
+  // Get address.
   $address = get_address($submittedValues, $webformFields);
   $postCode = $submittedValues[$webformFields['civicrm_1_contact_1_address_postal_code']][0];
 
-  // donot submit unless postcode is set.
+  // Do not submit unless postcode is set.
   if (!$postCode) {
-    return false;
+    return FALSE;
   }
 
   if (isset($submittedValues[$eligibilityFieldId])) {
@@ -87,16 +88,16 @@ function giftaid_wf_submission($node, $submission) {
 
 /**
  * Custom function to return giftaid eligibility field's form_key on a webform.
- * 
- * @return string|boolean
+ *
+ * @return string|bool
+ *   Form key name or FALSE if not found.
  */
 function get_eligibility_form_key_name() {
-  if(!defined('ELIGIBILITY_FIELD_KEY_PREFIX')) {
-    define('ELIGIBILITY_FIELD_KEY_PREFIX', 'civicrm_1_contribution_1_');
+  if (!defined('GIFTAID_WEBFORM_INTEGRATION_ELIGIBILITY_FIELD_KEY_PREFIX')) {
+    define('GIFTAID_WEBFORM_INTEGRATION_ELIGIBILITY_FIELD_KEY_PREFIX', 'civicrm_1_contribution_1_');
   }
   // CiviCRM boostrap.
   civicrm_initialize();
-  // Get custom group and custom field ID for Eligible_For_Gift_Field from CiviCRM.
   $customFieldData = civicrm_api3('CustomField', 'get', array(
     'sequential' => 1,
     'return' => "custom_group_id,id",
@@ -105,8 +106,8 @@ function get_eligibility_form_key_name() {
   ));
   /*
    * Webform_CiviCRM follows specific logic to name civicrm fields on webform.
-   * Below logic provides us the form_key assigned to "Eligible for Gift Aid" field
-   * on webform.
+   * Below logic provides us the form_key assigned to "Eligible for Gift Aid"
+   * field on webform.
    */
   if (!$customFieldData['is_error'] && $customFieldData['count'] > 0) {
     $customGroupId = $customFieldData['values'][0]['custom_group_id'];
@@ -114,30 +115,32 @@ function get_eligibility_form_key_name() {
 
     $fieldKey = "cg{$customGroupId}_custom_{$customFieldId}";
 
-    return ELIGIBILITY_FIELD_KEY_PREFIX . $fieldKey;
+    return GIFTAID_WEBFORM_INTEGRATION_ELIGIBILITY_FIELD_KEY_PREFIX . $fieldKey;
   }
-  return false;
+  return FALSE;
 }
 
 /**
- * Fetch address components from webform submission and return addresss as string.
- * 
- * @param array $submittedValues
- * @param array $webformFields
- * @return string $address
+ * Fetches address components from webform submission and parse them as string.
+ *
+ * @return string
+ *   Parsed address.
  */
 function get_address($submittedValues, $webformFields) {
-  $address = $submittedValues[$webformFields['civicrm_1_contact_1_address_street_address']][0] . ', ' 
-           . $submittedValues[$webformFields['civicrm_1_contact_1_address_city']][0] . ', ' 
+  $address = $submittedValues[$webformFields['civicrm_1_contact_1_address_street_address']][0] . ', '
+           . $submittedValues[$webformFields['civicrm_1_contact_1_address_city']][0] . ', '
            . $submittedValues[$webformFields['civicrm_1_contact_1_address_state_province_id']][0];
   return $address;
 }
 
 /**
  * Get receive_date from recently created contribution for the contact.
- * 
+ *
  * @param int $contactId
+ *   Contact id.
+ *
  * @return string
+ *   Contribution receive date.
  */
 function get_contribution_receive_date($contactId) {
   $result = civicrm_api3('Contribution', 'get', array(
@@ -154,9 +157,12 @@ function get_contribution_receive_date($contactId) {
 
 /**
  * Fetch all enabled fields for a webform.
- * 
+ *
  * @param int $webformNid
- * @return array $enabledFields
+ *   Webform node id.
+ *
+ * @return array
+ *   Enabled fields.
  */
 function get_webform_enabled_fields($webformNid) {
   $enabledFields = db_select('webform_component', 'wfc')
@@ -170,23 +176,23 @@ function get_webform_enabled_fields($webformNid) {
 
 /**
  * Function to check if the fields we are looking for exist on a webform.
- * 
- * @param array $enabledFields
- * @param array $fieldsToCheck
- * @return boolean
+ *
+ * @return bool
+ *   TRUE if all fields exist, FALSE otherwise.
  */
 function field_exists($enabledFields, $fieldsToCheck) {
   $fieldsNotPresent = array_diff($fieldsToCheck, $enabledFields);
   if ($fieldsNotPresent) {
-    return false;
+    return FALSE;
   }
-  return true;
+  return TRUE;
 }
 
 /**
  * Function to check if giftaid civicrm extension is installed for CiviCRM.
- * 
- * @return boolean
+ *
+ * @return bool
+ *   TRUE if extension is installed, FALSE otherwise.
  */
 function check_giftaid_installed() {
   civicrm_initialize();


### PR DESCRIPTION
## Overview
This PR adds the linter GitHub action, along with the required fixes for making it pass the same. Also, a minimal readme file was added. 

## Technical notes
In some cases the linter requires to add the type hints to the functions, if the `@param`s on the PHPDoc contains the type, but in those cases I just removed the param, because an incorrect hint could cause fatal errors on the execution.