### PR TITLE
CIVIPLMMSR-62: Fix issue with fetching webform fields

### DIFF
--- a/giftaid_webform_integration.module
+++ b/giftaid_webform_integration.module
@@ -169,7 +169,7 @@ function get_webform_enabled_fields($webformNid) {
     ->fields('wfc', array('form_key'))
     ->condition('nid', $webformNid, '=')
     ->execute()
-    ->fetchCol('form_key');
+    ->fetchCol();
 
   return $enabledFields;
 }


### PR DESCRIPTION
## Overview

This PR fixes the issue with the error that was being triggered when we try to submit any web form. This issue was caused by using the wrong method parameter type to fetch web form enabled fields.

## Before
![image](https://github.com/compucorp/giftaid_webform_integration/assets/2689257/beb856d6-224f-480e-8b72-2c7db00bf250)

## Technical Details

- We cannot pass a string to the `fetchCol` function; it only accepts an integer as a function parameter. Therefore, to make this work, we are removing the `form_key` from the `fetchCol` function call. Since we are fetching only a single column, we don't need to pass any function parameter, as it will default to the value `0`.
