### PR TITLE
CPO-728: Fix issues while using community version of gifaid extension

### DIFF
--- a/giftaid_webform_integration.module
+++ b/giftaid_webform_integration.module
@@ -82,7 +82,7 @@ function giftaid_wf_submission($node, $submission) {
       'post_code' => $postCode,
     );
     // Create giftaid declaration in CiviCRM.
-    CRM_Civigiftaid_Utils_GiftAid::setDeclaration($params);
+    CRM_Civigiftaid_Declaration::setDeclaration($params);
   }
 }
 
@@ -150,7 +150,7 @@ function get_contribution_receive_date($contactId) {
     'options' => array('sort' => "receive_date DESC", 'limit' => 1),
   ));
   if (!$result['is_error'] && $result['count'] > 0 && !empty($result['values'][0]['receive_date'])) {
-    return $result['values'][0]['receive_date'];
+    return (new DateTime($result['values'][0]['receive_date']))->format('YmdHis');
   }
   return date("Y-m-d h:i:s");
 }


### PR DESCRIPTION
## Overview

While we have switched to using the community version of the UK Gift Aid extension (https://lab.civicrm.org/extensions/ukgiftaid) instead of Compucorp's Gift Aid version (https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid), we are also changing the callbacks to align with the community version during this process.

## Before
![giftaid](https://github.com/compucorp/giftaid_webform_integration/assets/2689257/19932675-3545-4da8-a682-62c1fb55a8cc)

## Technical Details 

- Switching to changed class name as the community version has changed 
- Fix issue with date formatting. 