### PR TITLE
CPO-776: Remove validation message for home address location type

### DIFF
--- a/js/giftaid.admin.js
+++ b/js/giftaid.admin.js
@@ -7,10 +7,7 @@
                 var addressFieldName = "";
                 var fieldPartWeNeed = "";
                 var fieldsNotEnabled = [];
-                if ($('[name=contact_1_number_of_address]').val() == '0') {
-                    var msg = "You need to enable home address fields to make gift aid work.";
-                    return msg;
-                } else {
+                if ($('[name=contact_1_number_of_address]').val() != '0') {
                     var addressTypeElements = $("[name$=address_location_type_id]");
                     for (var i = 0; i < addressTypeElements.length; i++) {
                         var element = $('[name=' + addressTypeElements[i].name + ']');
@@ -43,18 +40,14 @@
                             var msg = "You must enable " + fieldsNotEnabled.join(', ') + " fields";
                             return msg;
                         }
-                    } else {
-                        var msg = "You need to enable home address fields to make gift aid work.";
-                        return msg;
                     }
-
                 }
             }
 
             function checkRequiredFields() {
                 if ($('[name=' + eligibilityFieldName + ']').prop('checked') == true) {
                     var msg = checkAddressFields();
-                    if (msg !== true) {
+                    if (msg !== true && msg !== undefined) {
                         if (!$('.giftaid-address-alert').length) {
                             $('[name=' + eligibilityFieldName + ']')
                                     .closest(".form-wrapper")


### PR DESCRIPTION
## Overview

This PR updates the webform integration validation by removing the validation error message that is displayed when clicking on 'Contribution Gift Aid Configuration' because this field should not be dependent on any address location type.

## Before
<img width="794" alt="18" src="https://github.com/compucorp/giftaid_webform_integration/assets/2689257/84d15f3a-5108-4115-b679-41323e6fd96b">

## After
![after-validation](https://github.com/compucorp/giftaid_webform_integration/assets/2689257/81889aeb-dcd5-4d50-848d-a7d8708d5c22)

## Technical Details

- Remove validation error message for home location type address.