### PR TITLE
CPO-777: Fix issue with disabling Eligible for Gift Aid field

### DIFF
--- a/giftaid_webform_integration.module
+++ b/giftaid_webform_integration.module
@@ -41,7 +41,9 @@ function giftaid_webform_integration_webform_submission_insert($node, $submissio
 function giftaid_webform_integration_form_alter(&$form, &$form_state, $form_id) {
   if (check_giftaid_installed()) {
     if ($form_id == 'wf_crm_configure_form') {
-      array_unshift($form['#attached']['js'], drupal_get_path('module', 'giftaid_webform_integration') . '/js/giftaid.admin.js');
+      if (isset($form['#attached']['js'])) {
+        array_unshift($form['#attached']['js'], drupal_get_path('module', 'giftaid_webform_integration') . '/js/giftaid.admin.js');
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

This PR fixes an issue with the 'Contribution Eligible for Gift Aid' field, where disabling the field was causing the webform to break.

## Before
![issue](https://github.com/compucorp/giftaid_webform_integration/assets/2689257/d424e5a7-b92d-4e52-b208-a9772e6dc2ad)

## After
![issue_after](https://github.com/compucorp/giftaid_webform_integration/assets/2689257/3fda4a07-50ed-47da-8ef0-daee1e24c3cc)

## Technical Details 

- Adding checking for below error 
![image](https://github.com/compucorp/giftaid_webform_integration/assets/2689257/329dab96-aecf-48c1-8a3b-bfd8b2a972d8)